### PR TITLE
Ensure exact dependencies are installed when using yarn add

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--add.exact true


### PR DESCRIPTION
This is how most deps seem to have been installed, so just enforcing this.